### PR TITLE
Fix: 兼容其它OpenAI格式模型供应结构

### DIFF
--- a/plugin/lib/ai.js
+++ b/plugin/lib/ai.js
@@ -81,8 +81,8 @@ const ROLE_PROMPTS = {
 // API URL 处理
 const API_ENDPOINTS = {
   [API_TYPES.OPENAI]: {
-    chat: "/v1/chat/completions",
-    models: "/v1/models",
+    chat: "/chat/completions",
+    models: "/models",
   },
   [API_TYPES.OLLAMA]: {
     chat: "/api/chat",


### PR DESCRIPTION
OpenAI接口一般用指定到“/v1”的URL进行baseURL配置，大部分项目也都是这么实现的，包括openai官方的python和JavaScript库也是要指定到“/v1”。如果将/v1视为endpoint的一部分会导致无法兼容很多家供应商的接口（如火山引擎的BaseURL以“/v3”结尾）。并且会违背大多数用户的配置直觉和习惯（OpenRouter以“/api/v1”结尾，用户大概率不知道应该如何配置）